### PR TITLE
docker: don't run brew as sudo

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,8 @@ RUN yum install sudo vim-enhanced which curl git -y
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8 && \
     useradd -m -s /bin/bash linuxbrew && \
     echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+
+USER linuxbrew
 RUN echo 'insecure' >> /home/linuxbrew/.curlrc
 RUN export HOMEBREW_FORCE_VENDOR_RUBY=1 && \
     git clone --depth=1 https://github.com/Linuxbrew/brew /home/linuxbrew/.linuxbrew && \
@@ -17,7 +19,7 @@ RUN export HOMEBREW_FORCE_VENDOR_RUBY=1 && \
     ln -s $(which gcc) /home/linuxbrew/.linuxbrew/bin/gcc-$(gcc -dumpversion|cut -d. -f1,2) && \
     ln -s $(which g++) /home/linuxbrew/.linuxbrew/bin/g++-$(g++ -dumpversion|cut -d. -f1,2) && \
     chown -R linuxbrew:linuxbrew /home/linuxbrew/.linuxbrew
-USER linuxbrew
+
 WORKDIR /home/linuxbrew
 ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH \
     SHELL=/bin/bash \


### PR DESCRIPTION
Since Linuxbrew can no longer be run with root privileges, we need to change to the linuxbrew user before running any brew commands.

Fixes #6.