### PR TITLE
portable-package: fix incorrect variable name

### DIFF
--- a/cmd/brew-portable-package.rb
+++ b/cmd/brew-portable-package.rb
@@ -20,7 +20,7 @@ ARGV.named.each do |name|
   safe_system "brew", "test", name
   puts "Library linkage:"
   if OS.linux?
-    puts Utils.open_read "ldd", "#{f.bin}/#{arg.gsub(/^portable-/, "")}"
+    puts Utils.open_read "ldd", "#{f.bin}/#{name.gsub(/^portable-/, "")}"
   else
     puts Utils.popen_read "brew", "linkage", name
   end


### PR DESCRIPTION
This stops portable-package from working at all on Linux.