### PR TITLE
portable-packages: improve dependency uninstallation

### DIFF
--- a/cmd/brew-portable-package.rb
+++ b/cmd/brew-portable-package.rb
@@ -16,7 +16,7 @@ ARGV.named.each do |name|
   name = "portable-#{name}" unless name.start_with? "portable-"
   f = Formula[name]
   safe_system "brew", "install", "--build-bottle", name
-  safe_system "brew uninstall --force $(brew deps --include-build #{name})"
+  safe_system "brew deps --include-build #{name} | xargs brew uninstall --force"
   safe_system "brew", "test", name
   puts "Library linkage:"
   if OS.linux?

--- a/cmd/brew-portable-package.rb
+++ b/cmd/brew-portable-package.rb
@@ -16,7 +16,7 @@ ARGV.named.each do |name|
   name = "portable-#{name}" unless name.start_with? "portable-"
   f = Formula[name]
   safe_system "brew", "install", "--build-bottle", name
-  safe_system "brew deps --include-build #{name} | xargs brew uninstall --force"
+  safe_system "brew deps --include-build #{name} | xargs brew uninstall --force --ignore-dependencies"
   safe_system "brew", "test", name
   puts "Library linkage:"
   if OS.linux?


### PR DESCRIPTION
- Use `xargs` instead of `$(…)` to handle the case where there are zero dependencies.
- Add the `--ignore-dependencies` flag, which was added since this was last updated.