### PR TITLE
OS X → macOS (where appropriate)

### DIFF
--- a/Abstract/portable-formula.rb
+++ b/Abstract/portable-formula.rb
@@ -4,7 +4,7 @@ module PortableFormulaMixin
     if OS.mac? && OS::Mac.version > tag
       opoo <<-EOS.undent
         You are building portable formula on #{OS::Mac.version}.
-        As result, formula won't be able to work for OS X at lower version.
+        As result, formula won't be able to work for macOS at lower version.
         It's recommended to build this formula on OS X #{tag.capitalize}.
       EOS
     end

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Formulae and tools to build versions of Ruby, Git and Curl that can be installed
 Just `brew install homebrew/portable/<formula>`.
 
 ## How do I build packages for these formulae?
-### OS X
-Run `brew portable-package <formula>` (ideally inside a OS X 10.5 VM so it is compatible with old OS X versions.
+### macOS
+Run `brew portable-package <formula>` (ideally inside an OS X 10.5 VM so it is compatible with old macOS versions.
 
 ### Linux
 Run `brew portable-package <formula>`. Ideally this should be run inside the CentOS 5 Docker container with:


### PR DESCRIPTION
I followed the convention established by Homebrew/brew@3f9cce0a03e967d2e7bcb7cd16bbc898c1a35708 and left references to specific versions released as "OS X" intact.