### PR TITLE
Fix git on Tiger

### DIFF
--- a/Formula/portable-git.rb
+++ b/Formula/portable-git.rb
@@ -7,7 +7,9 @@ class PortableGit < PortableFormula
   sha256 "ec0283d78a0f1c8408c5fd43610697b953fbaafe4077bb1e41446a9ee3a2f83d"
 
   depends_on "portable-curl" => :build
-  depends_on "portable-expat" => :build if OS.linux?
+  if OS.linux? || OS::Mac.version < :leopard
+    depends_on "portable-expat" => :build
+  end
 
   def install
     curl = Formula["portable-curl"]
@@ -30,7 +32,9 @@ class PortableGit < PortableFormula
     ENV["NO_GETTEXT"] = "1"
     ENV["NO_TCLTK"] = "1"
     ENV["NO_OPENSSL"] = "1"
-    ENV["EXPATDIR"] = expat.opt_prefix if OS.linux?
+    if OS.linux? || OS::Mac.version < :leopard
+      ENV["EXPATDIR"] = expat.opt_prefix
+    end
     args = %W[
       prefix=#{prefix}
       CC=#{ENV.cc}

--- a/Formula/portable-git.rb
+++ b/Formula/portable-git.rb
@@ -6,6 +6,11 @@ class PortableGit < PortableFormula
   url "https://www.kernel.org/pub/software/scm/git/git-2.8.2.tar.xz"
   sha256 "ec0283d78a0f1c8408c5fd43610697b953fbaafe4077bb1e41446a9ee3a2f83d"
 
+  if MacOS.version < :leopard
+    # system tar has odd permissions errors
+    depends_on "gnu-tar" => :build
+  end
+
   depends_on "portable-curl" => :build
   if OS.linux? || OS::Mac.version < :leopard
     depends_on "portable-expat" => :build
@@ -20,6 +25,15 @@ class PortableGit < PortableFormula
   end
 
   def install
+    if MacOS.version < :leopard
+      tar = Formula["gnu-tar"]
+      tab = Tab.for_keg tar.installed_prefix
+      tar_name = tab.used_options.include?("--with-default-names") ? tar.bin/"tar" : tar.bin/"gtar"
+      inreplace "Makefile" do |s|
+        s.change_make_var! "TAR", tar_name.to_s
+      end
+    end
+
     curl = Formula["portable-curl"]
     expat = Formula["portable-expat"]
 

--- a/Formula/portable-git.rb
+++ b/Formula/portable-git.rb
@@ -11,6 +11,14 @@ class PortableGit < PortableFormula
     depends_on "portable-expat" => :build
   end
 
+  # ld64 understands -rpath but rejects it on Tiger
+  if MacOS.version < :leopard
+    patch :p1 do
+      url "https://trac.macports.org/export/106975/trunk/dports/devel/git-core/files/patch-Makefile.diff"
+      sha1 "f033e5b78ecbfcc14b7994f98a74dfdbe607eea0"
+    end
+  end
+
   def install
     curl = Formula["portable-curl"]
     expat = Formula["portable-expat"]


### PR DESCRIPTION
* Work around Tiger's ld's lack of `-rpath`
* Use gnu-tar to work around quirks in the system tar
* Use portable-expat, since Tiger's expat is only included in X11 (and is very old)

cc @xu-cheng 