### PR TITLE
portable-curl: fix for Linux

### DIFF
--- a/Formula/portable-c-ares.rb
+++ b/Formula/portable-c-ares.rb
@@ -1,0 +1,35 @@
+require File.expand_path("../../Abstract/portable-formula", __FILE__)
+
+class PortableCAres < PortableFormula
+  desc "Asynchronous DNS library"
+  homepage "https://c-ares.haxx.se/"
+  url "https://c-ares.haxx.se/download/c-ares-1.12.0.tar.gz"
+  mirror "https://launchpad.net/ubuntu/+archive/primary/+files/c-ares_1.12.0.orig.tar.gz"
+  sha256 "8692f9403cdcdf936130e045c84021665118ee9bfea905d1a76f04d4e6f365fb"
+
+  def install
+    ENV.universal_binary if build.with? "universal"
+    system "./configure", "--prefix=#{prefix}",
+                          "--disable-dependency-tracking",
+                          "--disable-debug",
+                          "--enable-static",
+                          "--disable-shared"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <stdio.h>
+      #include <ares.h>
+
+      int main()
+      {
+        ares_library_init(ARES_LIB_INIT_ALL);
+        ares_library_cleanup();
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lcares", "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/portable-curl.rb
+++ b/Formula/portable-curl.rb
@@ -8,7 +8,10 @@ class PortableCurl < PortableFormula
 
   depends_on "portable-openssl" => :build
   depends_on "pkg-config" => :build
-  depends_on "portable-zlib" => :build if OS.linux?
+  if OS.linux?
+    depends_on "portable-zlib" => :build
+    depends_on "portable-c-ares" => :build
+  end
 
   # Ref: https://curl.haxx.se/mail/archive-2003-03/0115.html
   #      https://curl.haxx.se/mail/lib-2011-12/0093.html
@@ -24,10 +27,17 @@ class PortableCurl < PortableFormula
       --prefix=#{prefix}
       --with-ssl=#{Formula["portable-openssl"].opt_prefix}
       --disable-ldap
-      --disable-ares
       --without-librtmp
       --without-libidn
     ]
+
+    if OS.mac?
+      args << "--disable-ares"
+    else
+      cares = Formula["portable-c-ares"]
+      args << "--enable-ares=#{cares.opt_prefix}"
+      ENV.append "LIBS", "-L#{cares.opt_prefix}/lib -lcares"
+    end
 
     dirs = []
 

--- a/README.md
+++ b/README.md
@@ -16,26 +16,25 @@ docker run -t -i homebrew-portable /bin/bash
 brew portable-package <formula>
 ```
 
-## Current status
+## Current Status
 
-| Formula | macOS 10.12 | OS X 10.5 | OS X 10.4 | Linuxbrew[0] |
+| Formula | macOS 10.12 | OS X 10.5 | OS X 10.4 | Linuxbrew(x86_64) |
 | :-: | :-: | :-: | :-: | :-: |
+| c-ares | N/A | N/A | N/A | :white_check_mark: |
 | zlib | N/A | N/A | N/A | :white_check_mark: |
 | ncurses | N/A | N/A | N/A | :white_check_mark: |
 | expat | N/A | N/A | :white_check_mark: | :white_check_mark: |
 | OpenSSL | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Readline | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | libYAML | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Ruby | :white_check_mark::warning: (64 bit only)[1] | :white_check_mark::warning: (32/64 bit only)[1] | :white_check_mark: (Single arch only)[1] | :white_check_mark::warning: [3] |
-| Curl | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: [2] |
+| Ruby | :white_check_mark::warning: (64 bit only)[1] | :white_check_mark::warning: (32/64 bit only)[1] | :white_check_mark: (Single arch only)[1] | :white_check_mark::warning: [2] |
+| Curl | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Git | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 macOS/OS X builds on 10.6 and newer target 32-bit/64-bit Intel Macs. OS X builds on 10.4 and 10.5 target 32-bit PowerPC and Intel Macs.
 
-* [0]: Linuxbrew is 64 bit only, which should be built in CentOS docker using system libraries and compiler.
-* [1]: Fail on universal build. https://gist.github.com/cb5e6b142c39116dbe0b954885f1054e. It appears to be Ruby's bug, as it's fixed for Ruby 2.1.
-* [2]: Binary files report segment fault when running on CentOS 6(work fine on CentOS 5)
-* [3]: Linux build `irb` seems to fail to link staticly to ncurses. If `portable-ncurses` is removed, `irb` will fail to handle left, right or backspace keystroke.
+1. Fail on universal build. https://gist.github.com/cb5e6b142c39116dbe0b954885f1054e. It appears to be Ruby's bug, as it's fixed for Ruby 2.1.
+2. Linux build `irb` seems to fail to link staticly to ncurses. If `portable-ncurses` is removed, `irb` will fail to handle left, right or backspace keystroke.
 
 
 ## License


### PR DESCRIPTION
Fix portable-c-ares for Linux by linking to c-ares.