### PR TITLE
Add portable-ruby@2.2

### DIFF
--- a/Abstract/portable-formula.rb
+++ b/Abstract/portable-formula.rb
@@ -43,8 +43,8 @@ class PortableFormula < Formula
     subclass.class_eval do
       keg_only "Portable formula is keg-only."
 
-      # TODO remove `subclass.name !~ /PortableRuby/` when updating portable-ruby to 2.1 or above.
-      option "without-universal", "Don't build a universal binary" if OS.mac? && subclass.name !~ /PortableRuby/
+      # TODO remove `subclass.name !~ /PortableRuby$/` when updating portable-ruby to 2.1 or above.
+      option "without-universal", "Don't build a universal binary" if OS.mac? && subclass.name !~ /PortableRuby$/
 
       prepend PortableFormulaMixin
     end

--- a/Formula/portable-ruby@2.2.rb
+++ b/Formula/portable-ruby@2.2.rb
@@ -1,0 +1,108 @@
+require File.expand_path("../../Abstract/portable-formula", __FILE__)
+
+class PortableRubyAT22 < PortableFormula
+  desc "Portable ruby 2.2"
+  homepage "https://www.ruby-lang.org/"
+  url "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.7.tar.gz"
+  sha256 "374184c6c5bbc88fb7bad422368d4053a236fb6587f0eff76146dcba57f93da5"
+
+  depends_on "makedepend" => :build
+  depends_on "pkg-config" => :build
+  depends_on "portable-readline" => :build
+  depends_on "portable-libyaml" => :build
+  depends_on "portable-openssl" => :build
+  if OS.linux?
+    depends_on "portable-ncurses" => :build
+    depends_on "portable-zlib" => :build
+  end
+
+  def install
+    ENV.append "LDFLAGS", "-Wl,-search_paths_first"
+
+    readline = Formula["portable-readline"]
+    libyaml = Formula["portable-libyaml"]
+    openssl = Formula["portable-openssl"]
+    ncurses = Formula["portable-ncurses"]
+    zlib = Formula["portable-zlib"]
+
+    args = %W[
+      --prefix=#{prefix}
+      --enable-load-relative
+      --with-static-linked-ext
+      --disable-dln
+      --with-out-ext=tk,sdbm,gdbm,dbm,dl,coverage,fiddle
+      --disable-install-doc
+      --disable-install-rdoc
+      --disable-dtrace
+    ]
+
+    if OS.mac? && build.with?("universal")
+      args << "--with-arch=#{archs.join(",")}"
+    end
+
+    paths = [
+      readline.opt_prefix,
+      libyaml.opt_prefix,
+      openssl.opt_prefix,
+    ]
+
+    if OS.linux?
+      # We want Ruby to link to our ncurses, instead of libtermcap in CentOS 5
+      paths << ncurses.opt_prefix
+      inreplace "ext/readline/extconf.rb" do |s|
+        s.gsub! "dir_config('termcap')", ""
+        s.gsub! 'have_library("termcap", "tgetnum") ||', ""
+      end
+      inreplace "ext/curses/extconf.rb" do |s|
+        s.gsub! "dir_config('termcap')", ""
+        s.gsub! 'or have_library("termcap", "tgetent")', ""
+      end
+
+      paths << zlib.opt_prefix
+    end
+
+    args << "--with-opt-dir=#{paths.join(":")}"
+
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+
+    abi_version = `#{bin}/ruby -rrbconfig -e 'print RbConfig::CONFIG["ruby_version"]'`
+    abi_arch = `#{bin}/ruby -rrbconfig -e 'print RbConfig::CONFIG["arch"]'`
+    inreplace lib/"ruby/#{abi_version}/#{abi_arch}/rbconfig.rb" do |s|
+      s.gsub! ENV.cxx, "c++"
+      s.gsub! ENV.cc, "cc"
+    end
+
+    libexec.mkpath
+    cp openssl.opt_libexec/"etc/openssl/cert.pem", libexec/"cert.pem"
+    openssl_rb = lib/"ruby/#{abi_version}/openssl.rb"
+    openssl_rb_content = openssl_rb.read
+    rm openssl_rb
+    openssl_rb.write <<-EOS.undent
+      ENV["SSL_CERT_FILE"] ||= File.expand_path("../../libexec/cert.pem", RbConfig.ruby)
+      #{openssl_rb_content}
+    EOS
+  end
+
+  test do
+    cp_r Dir["#{prefix}/*"], testpath
+    ENV["PATH"] = "/usr/bin:/bin"
+    ruby = (testpath/"bin/ruby").realpath
+    assert_equal version.to_s.split("-").first, shell_output("#{ruby} -e 'puts RUBY_VERSION'").strip
+    assert_equal ruby.to_s, shell_output("#{ruby} -e 'puts RbConfig.ruby'").strip
+    assert_equal "3632233996",
+      shell_output("#{ruby} -rzlib -e 'puts Zlib.crc32(\"test\")'").strip
+    assert_equal "\"'",
+      shell_output("#{ruby} -rreadline -e 'puts Readline.basic_quote_characters'").strip
+    assert_equal '{"a"=>"b"}',
+      shell_output("#{ruby} -ryaml -e 'puts YAML.load(\"a: b\")'").strip
+    assert_equal "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      shell_output("#{ruby} -ropenssl -e 'puts OpenSSL::Digest::SHA256.hexdigest(\"\")'").strip
+    assert_match "200",
+      shell_output("#{ruby} -ropen-uri -e 'open(\"https://google.com\") { |f| puts f.status.first }'").strip
+    system testpath/"bin/gem", "environment"
+    system testpath/"bin/gem", "install", "bundler"
+    system testpath/"bin/bundle", "init"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ brew portable-package <formula>
 | Readline | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | libYAML | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Ruby | :white_check_mark::warning:[1] | :white_check_mark::warning:[1] | :white_check_mark::warning:[1] | :white_check_mark::warning:[2] |
+| Ruby 2.2 | :white_check_mark: | :white_check_mark: | :white_check_mark: | :question: |
 | Curl | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Git | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 


### PR DESCRIPTION
This adds a formula for Ruby 2.2, the newest version that currently builds universal when statically linked. Ruby 2.3 and 2.4 currently don't build [due to a bug with statically linked ext](https://bugs.ruby-lang.org/issues/13413). This also includes a patch that scopes the universal workaround to only be applied to `portable-ruby`, not other Ruby versions.

Universal is important for me with Tigerbrew, as I'll want to be shipping a single binary for both PowerPC and Intel. I also prefer shipping a version that's currently supported upstream; 2.0 and 2.1 are both EOL.