### PR TITLE
portable-ruby@2.2: fix build on PPC and Tiger

### DIFF
--- a/Formula/portable-ruby@2.2.rb
+++ b/Formula/portable-ruby@2.2.rb
@@ -6,6 +6,7 @@ class PortableRubyAT22 < PortableFormula
   url "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.7.tar.gz"
   sha256 "374184c6c5bbc88fb7bad422368d4053a236fb6587f0eff76146dcba57f93da5"
 
+  depends_on "make" => :build if OS.mac? && MacOS.version < :leopard
   depends_on "makedepend" => :build
   depends_on "pkg-config" => :build
   depends_on "portable-readline" => :build
@@ -90,8 +91,8 @@ class PortableRubyAT22 < PortableFormula
     args << "--with-opt-dir=#{paths.join(":")}"
 
     system "./configure", *args
-    system "make"
-    system "make", "install"
+    make
+    make "install"
 
     abi_version = `#{bin}/ruby -rrbconfig -e 'print RbConfig::CONFIG["ruby_version"]'`
     abi_arch = `#{bin}/ruby -rrbconfig -e 'print RbConfig::CONFIG["arch"]'`

--- a/Formula/portable-ruby@2.2.rb
+++ b/Formula/portable-ruby@2.2.rb
@@ -37,6 +37,11 @@ class PortableRubyAT22 < PortableFormula
     ]
 
     if OS.mac? && build.with?("universal")
+      if MacOS.version < :snow_leopard
+        # This will break the 32-bit PPC slice otherwise
+        ENV.replace_in_cflags(/-march=\S*/, "-Xarch_i386 \\0")
+        ENV.replace_in_cflags(/-mcpu=\S*/, "-Xarch_ppc \\0")
+      end
       args << "--with-arch=#{archs.join(",")}"
     end
 


### PR DESCRIPTION
* Fix access to the `mcontext` struct, used on Intel, which changed shape between 10.4 and 10.5.
* Fix the universal `CFLAGS` by ensuring GCC doesn't interpret `-march` as an argument to be used when `-arch` is `ppc`.
* Tiger's make (3.80) is too old to understand Ruby's makefile; 3.81 or later is needed.