### PR TITLE
tweak LDFLAGS

### DIFF
--- a/Abstract/portable-formula.rb
+++ b/Abstract/portable-formula.rb
@@ -1,24 +1,27 @@
 module PortableFormulaMixin
   def install
-    tag = Hardware::CPU.ppc? ? :tiger : :leopard
-    if OS.mac? && OS::Mac.version > tag
-      opoo <<-EOS.undent
-        You are building portable formula on #{OS::Mac.version}.
-        As result, formula won't be able to work for macOS at lower version.
-        It's recommended to build this formula on OS X #{tag.capitalize}.
-      EOS
-    end
+    if OS.mac?
+      tag = Hardware::CPU.ppc? ? :tiger : :leopard
+      if OS::Mac.version > tag
+        opoo <<-EOS.undent
+          You are building portable formula on #{OS::Mac.version}.
+          As result, formula won't be able to work for macOS at lower version.
+          It's recommended to build this formula on OS X #{tag.capitalize}.
+        EOS
+      end
 
-    # Overrideable per-formula, but try to make sure our universal
-    # arches make it into the environment.
-    # This is important because in some environments (e.g. 10.4/10.5)
-    # our arches differ from the usual defaults.
-    if OS.mac? && build.with?("universal")
-      ENV.permit_arch_flags
-      ENV.append_to_cflags archs.map {|a| "-arch #{a}"}.join(" ")
-    end
+      # Overrideable per-formula, but try to make sure our universal
+      # arches make it into the environment.
+      # This is important because in some environments (e.g. 10.4/10.5)
+      # our arches differ from the usual defaults.
+      if build.with?("universal")
+        ENV.permit_arch_flags
+        ENV.append_to_cflags archs.map {|a| "-arch #{a}"}.join(" ")
+      end
 
-    if OS.linux?
+      # Always prefer to linking to portable libs.
+      ENV.append "LDFLAGS", "-Wl,-search_paths_first"
+    elsif OS.linux?
       # reset Linuxbrew env, because we want to build formula against
       # libraries offered by system (CentOS docker) rather than Linuxbrew.
       ENV.delete "LDFLAGS"

--- a/Formula/portable-curl.rb
+++ b/Formula/portable-curl.rb
@@ -18,6 +18,7 @@ class PortableCurl < PortableFormula
   def install
     ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["portable-openssl"].opt_lib}/pkgconfig"
     ENV["LIBS"] = `pkg-config openssl --static --libs`.chomp
+
     args = %W[
       --disable-debug
       --disable-dependency-tracking
@@ -51,7 +52,9 @@ class PortableCurl < PortableFormula
 
       system "./configure", *args
       system "make", "clean"
-      system "make", "LDFLAGS=-all-static -Wl,-search_paths_first"
+      ENV.append "LDFLAGS", "-all-static"
+      system "make"
+      ENV.remove "LDFLAGS", "-all-static"
       system "make", "install"
 
       if build.with? "universal"

--- a/Formula/portable-git.rb
+++ b/Formula/portable-git.rb
@@ -40,7 +40,6 @@ class PortableGit < PortableFormula
     expat = Formula["portable-expat"]
     zlib = Formula["portable-zlib"]
 
-    ENV.append "LDFLAGS", "-Wl,-search_paths_first"
     ENV.universal_binary if build.with? "universal"
 
     # Git Makefile doesn't support to link static libcurl.

--- a/Formula/portable-ruby.rb
+++ b/Formula/portable-ruby.rb
@@ -23,8 +23,6 @@ class PortableRuby < PortableFormula
   end
 
   def install
-    ENV.append "LDFLAGS", "-Wl,-search_paths_first"
-
     readline = Formula["portable-readline"]
     libyaml = Formula["portable-libyaml"]
     openssl = Formula["portable-openssl"]

--- a/Formula/portable-ruby@2.2.rb
+++ b/Formula/portable-ruby@2.2.rb
@@ -39,8 +39,6 @@ class PortableRubyAT22 < PortableFormula
       end
     end
 
-    ENV.append "LDFLAGS", "-Wl,-search_paths_first"
-
     readline = Formula["portable-readline"]
     libyaml = Formula["portable-libyaml"]
     openssl = Formula["portable-openssl"]

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ brew portable-package <formula>
 | OpenSSL | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Readline | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | libYAML | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Ruby | :white_check_mark::warning:[1] | :white_check_mark::warning:[1] | :white_check_mark::warning:[1] | :white_check_mark::warning:[2] |
-| Ruby 2.2 | :white_check_mark: | :white_check_mark: | :white_check_mark: | :question: |
+| Ruby 2.0 | :white_check_mark::warning:[1] | :white_check_mark::warning:[1] | :white_check_mark::warning:[1] | :white_check_mark::warning:[2] |
+| Ruby 2.2 | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark::warning:[2] |
 | Curl | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Git | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 


### PR DESCRIPTION
* Enable `-Wl,search_paths_first` for all formulae on macOS to prefer to
  using our portable static libraries.
* Do not pass `-Wl,search_paths_first` on Linux. It is an invalid flag for
  gcc, which always prefers to paths specified by `-L` already.
* Refactor `PortableFormulaMixin#install`.