### PR TITLE
curl: fix replacing CFLAGS

### DIFF
--- a/Formula/portable-curl.rb
+++ b/Formula/portable-curl.rb
@@ -43,7 +43,10 @@ class PortableCurl < PortableFormula
 
     archs.each do |arch|
       if build.with? "universal"
-        ENV["CFLAGS"] = "-arch #{arch}"
+        # Can't use ENV.remove_from_cflags because we want to
+        # remove *all* occurrences, not just one.
+        ENV["CFLAGS"] = ENV["CFLAGS"].gsub(/(-arch \S*|-Xarch_\S*|-march=\S*)/, "")
+        ENV.append_to_cflags "-arch #{arch}"
         dir = "build-#{arch}"
         dirs << dir
         mkdir dir


### PR DESCRIPTION
curl sets `-mmacosx-version-min=10.8` in CFLAGS if not otherwise specified, and since we're overriding CFLAGS, the value set by stdenv gets erased. This does a more conservative replacement, which only strips arch-related flags.