### PR TITLE
portable-git: needs openssl on Tiger/Leopard

### DIFF
--- a/Formula/portable-git.rb
+++ b/Formula/portable-git.rb
@@ -16,6 +16,7 @@ class PortableGit < PortableFormula
     depends_on "portable-expat" => :build
   end
 
+  depends_on "portable-openssl" => :build
   depends_on "portable-zlib" => :build if OS.linux?
 
   # ld64 understands -rpath but rejects it on Tiger
@@ -57,7 +58,6 @@ class PortableGit < PortableFormula
     ENV["NO_PERL_MAKEMAKER"] = "1"
     ENV["NO_GETTEXT"] = "1"
     ENV["NO_TCLTK"] = "1"
-    ENV["NO_OPENSSL"] = "1"
     if OS.linux? || OS::Mac.version < :leopard
       ENV["EXPATDIR"] = expat.opt_prefix
     end


### PR DESCRIPTION
Tigerbrew already does this; the version on Tiger is too old to build git, and Leopard's is realistically too old to want to use as well. While CommonCrypto is shipped on Leopard, I trust modern OpenSSL more than I trust 10-year-old CommonCrypto.