### PR TITLE
openssl: don't run `make test` for incompatible archs

### DIFF
--- a/Formula/portable-openssl.rb
+++ b/Formula/portable-openssl.rb
@@ -86,7 +86,7 @@ class PortableOpenssl < PortableFormula
       system "perl", "./Configure", *(configure_args + arch_args[arch])
       system "make", "depend"
       system "make"
-      system "make", "test"
+      system "make", "test" if Hardware::CPU.can_run? arch
 
       if build.with? "universal"
         cp "include/openssl/opensslconf.h", dir


### PR DESCRIPTION
It's possible that we might be building a universal binary on a platform that can't run code for every arch it's building. Examples include:

* Building a ppc/i386 openssl on a PowerPC Mac, which can't run i386 binaries
* Building an i386/x86_64 openssl on an i386 Mac, which can't run x86_64 binaries

openssl's `make test` requires actually running code, so it will fail if run on a platform that can't execute code for the architecture being tested. This uses `Hardware::CPU.can_run?` from Homebrew/brew#2496 to guard `make test` calls.