### PR TITLE
rewrite portable-package cmd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - ulimit -n 1024
 script:
   - brew test-bot --skip-relocation
-  - brew portable-package portable-ruby
+  - brew portable-package --write portable-ruby
 notifications:
   email:
     on_success: never

--- a/cmd/brew-portable-package.rb
+++ b/cmd/brew-portable-package.rb
@@ -1,28 +1,54 @@
-# Build a portable Homebrew utility bottle.
-#
-# Usage: brew portable-package <formula> [formula...]
+#: `brew` `portable-package` [`--no-uninstall-deps`] [`--no-rebuild`|`--keep-old`] [`--write` [`--no-commit`]] <formulae>:
+#:    Build and package portable formulae.
+#:
+#:    Unless `--uninstall-deps` is passed, all dependencies of portable
+#:    formulae will be uninstalled before test. Useful for developing purpose.
+#:
+#:    If the formula specifies a rebuild version, it will be incremented in the
+#:    generated DSL. Passing `--keep-old` will attempt to keep it at its
+#:    original value, while `--no-rebuild` will remove it.
+#:
+#:    If `--write` is passed, write the changes to the formula file.
+#:    A new commit will then be generated unless `--no-commit` is passed.
 
-odie "Need to specify at least one portable formula!" if ARGV.empty?
-
-if RUBY_VERSION.split(".").first.to_i < 2
-  safe_system "brew", "install", "ruby"
-  ENV["HOMEBREW_RUBY_PATH"] = "#{HOMEBREW_PREFIX}/bin/ruby"
-end
-
-ENV["HOMEBREW_PREFER_64_BIT"] = "1"
 ENV["HOMEBREW_DEVELOPER"] = "1"
+
+include FileUtils
+
+BOTTLE_ARGS = %w[
+  --no-rebuild
+  --keep-old
+  --write
+  --no-commit
+].freeze
 
 ARGV.named.each do |name|
   name = "portable-#{name}" unless name.start_with? "portable-"
-  f = Formula[name]
-  safe_system "brew", "install", "--build-bottle", name
-  safe_system "brew deps --include-build #{name} | xargs brew uninstall --force --ignore-dependencies"
-  safe_system "brew", "test", name
-  puts "Library linkage:"
-  if OS.linux?
-    puts Utils.popen_read "ldd", "#{f.bin}/#{name.gsub(/^portable-/, "")}"
-  else
-    puts Utils.popen_read "brew", "linkage", name
+  begin
+    safe_system "brew", "install", "--build-bottle", name
+    unless ARGV.include? "--no-uninstall-deps"
+      deps = Utils.popen_read("brew", "deps", "--include-build", name).split("\n")
+      deps.each do |dep|
+        safe_system "brew", "uninstall", "--force", "--ignore-dependencies", dep
+      end
+    end
+    safe_system "brew", "test", name
+    puts "Linkage information:"
+    safe_system "brew", "linkage", name
+    bottle_args = %w[--skip-relocation]
+    bottle_args += ARGV.select { |arg| BOTTLE_ARGS.include? arg }
+    safe_system "brew", "bottle", *bottle_args, name
+    Pathname.glob("*.bottle*.tar.gz") do |bottle_filename|
+      bottle_file = bottle_filename.realpath
+      bottle_cache = HOMEBREW_CACHE/bottle_filename
+      ln bottle_file, bottle_cache, force: true
+    end
+  rescue => e
+    ofail e
   end
-  safe_system "brew", "bottle", "--skip-relocation", name
+end
+
+Pathname.glob("*.bottle*.tar.gz") do |bottle_filename|
+  bottle_cache = HOMEBREW_CACHE/bottle_filename
+  rm_f bottle_cache
 end


### PR DESCRIPTION
* Better help message.
* Remove obsoleted ruby version check. Homebrew should always run with
  Ruby 2.0+ now. At the same time, old ruby check won't work as it will
  just crash when loading formula if Homebrew is somehow run with Ruby
  1.8.
* Remove obsoleted HOMEBREW_PREFER_64_BIT. We start to build 32bit formulae
  on OS X older than Snow Leopard since 6a3a192a65dfa16636525aa90438e9164ba5e9c0.
* Add new option to not uninstall deps, useful for developing.
* Use `Utils.popen_read` instead of pipe to enforce proper shell esecape.
  Otherwise, `brew portable-package some_shell_code_injection` will :boom:.
* Use `brew linkage` on both Mac and Linux. Previously,
  `ldd #{f.bin}/#{name.gsub(/^portable-/, "")}` will break for non elf
  file.
* Use `safe_system`, instead of superfluous `puts Utils.popen_read`.
* Support various bottle options.
* Reuse existing bottles when building multiple formulae.