### PR TITLE
Abstract/portable-formula: Tweak keg_only reason

### DIFF
--- a/Abstract/portable-formula.rb
+++ b/Abstract/portable-formula.rb
@@ -46,7 +46,7 @@ end
 class PortableFormula < Formula
   def self.inherited(subclass)
     subclass.class_eval do
-      keg_only "Portable formula is keg-only."
+      keg_only "portable formulae are keg-only"
 
       # TODO remove `subclass.name !~ /PortableRuby$/` when updating portable-ruby to 2.1 or above.
       option "without-universal", "Don't build a universal binary" if OS.mac? && subclass.name !~ /PortableRuby$/


### PR DESCRIPTION
Make it lowercase and not end with a period, because
it fits in with the caveats sentece better that way.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>