### PR TITLE
portable-openssl 1.0.2l

### DIFF
--- a/Formula/portable-openssl.rb
+++ b/Formula/portable-openssl.rb
@@ -3,10 +3,9 @@ require File.expand_path("../../Abstract/portable-formula", __FILE__)
 class PortableOpenssl < PortableFormula
   desc "Portable OpenSSL"
   homepage "https://openssl.org/"
-  url "https://www.openssl.org/source/openssl-1.0.2k.tar.gz"
-  mirror "https://dl.bintray.com/homebrew/mirror/openssl-1.0.2k.tar.gz"
-  mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-1.0.2k.tar.gz"
-  sha256 "6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0"
+  url "https://www.openssl.org/source/openssl-1.0.2l.tar.gz"
+  mirror "https://dl.bintray.com/homebrew/mirror/openssl-1.0.2l.tar.gz"
+  sha256 "ce07195b659e75f4e1db43552860070061f156a98bb37b672b101ba6e3ddf30c"
 
   depends_on "makedepend" => :build
   depends_on "portable-zlib" => :build if OS.linux?


### PR DESCRIPTION
Extracted from https://github.com/Homebrew/homebrew-portable/pull/44.