### PR TITLE
portable-openssl: Add http mirror

### DIFF
--- a/Formula/portable-openssl.rb
+++ b/Formula/portable-openssl.rb
@@ -13,6 +13,7 @@ class PortableOpenssl < PortableFormula
   resource "cacert" do
     # http://curl.haxx.se/docs/caextract.html
     url "https://curl.haxx.se/ca/cacert-2017-01-18.pem"
+    mirror "http://cdn.rawgit.com/sjackman/e4066d2cb6b45fbb6d213e676cb109d0/raw/58964378cb5eefe96cba245ef863c57fb2b480e0/cacert-2017-01-18.pem"
     sha256 "e62a07e61e5870effa81b430e1900778943c228bd7da1259dd6a955ee2262b47"
   end
 


### PR DESCRIPTION
Fix the error:
```
==> Downloading from https://curl.haxx.se/ca/cacert-2017-01-18.pem
curl: (35) error:1407742E:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert protocol version
```

Note that http://curl.haxx.se redirects to https://curl.haxx.se